### PR TITLE
Switch to flakeheaven

### DIFF
--- a/requirements/static_analysis.txt
+++ b/requirements/static_analysis.txt
@@ -1,10 +1,8 @@
 bandit~=1.7
-black
-flakehell
-# flakehell is incompatible with flake8==3.9.1
-flake8<3.9.1
+black~=22.3
+flakeheaven~=1.0.1
 flake8-docstrings
 flake8-print
 flake8-spellcheck
-isort
+isort~=5.10.1
 safety


### PR DESCRIPTION
* use stable version of Blake
* use `flakeheaven` instead of `flakehell`
   > flakeheaven is a fork of [FlakeHell](https://github.com/life4/flakehell). FlakeHell and other forks of it such as flakehell/flakehell are [no longer maintained](https://github.com/flakehell/flakehell/issues/25) and do not work with Flake8 4.0.x.