### PR TITLE
Update black to latest version.

### DIFF
--- a/requirements/static_analysis.txt
+++ b/requirements/static_analysis.txt
@@ -1,5 +1,5 @@
 bandit~=1.7
-black~=22.3
+black~=23.1
 djlint
 flakeheaven~=1.0.1
 flake8-docstrings


### PR DESCRIPTION
A new version of black for 2023 as per their [stability policy](https://black.readthedocs.io/en/stable/the_black_code_style/index.html#stability-policy)

[Full Change log](https://black.readthedocs.io/en/stable/change_log.html#id1)
