### PR TITLE
Pin pip-audit to 2.5.2

### DIFF
--- a/requirements/static_analysis.txt
+++ b/requirements/static_analysis.txt
@@ -6,4 +6,6 @@ flake8-docstrings
 flake8-print
 flake8-spellcheck
 isort~=5.10
-pip_audit~=2.4
+# Pip-audit 2.5.3 changes package resolution
+# and attempts to install psycopg2 from source
+pip-audit==2.5.2


### PR DESCRIPTION
Some change to pip-audit 2.5.3 breaks our workflow, as it tries to build psycopg2 from source, instead of just referencing the version in the constraints file