### PR TITLE
Prepare for v3

### DIFF
--- a/requirements/static_analysis.txt
+++ b/requirements/static_analysis.txt
@@ -1,15 +1,6 @@
 bandit~=1.7
 black~=24.4
-djlint
-flakeheaven~=3.3
-flake8-docstrings
-flake8-print
-flake8-spellcheck
-isort~=5.10
-# urllib3 v2 updates break cachecontrol, an upstream dependency of pip-audit
-# https://github.com/ionrock/cachecontrol/pull/294
-urllib3<2
-# Pip-audit 2.5.3 changes package resolution
-# and attempts to install psycopg2 from source
-pip-audit==2.5.2
-ruff
+djlint~=1.34
+isort~=5.13
+pip-audit~=2.7.3
+ruff==0.4.4

--- a/requirements/static_analysis.txt
+++ b/requirements/static_analysis.txt
@@ -1,5 +1,5 @@
 bandit~=1.7
-black~=23.1
+black~=24.4
 djlint
 flakeheaven~=3.3
 flake8-docstrings


### PR DESCRIPTION
Add Black 24.

~~New major version https://github.com/springload/python-static-analysis/releases/tag/3.0.0~~
(deleted tag until this is merged)